### PR TITLE
add test to check latest available es version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 hot
 git+https://github.com/JasonBoyles/envshuffle
 git+https://github.com/JasonBoyles/bumper
+git+https://github.com/sigmavirus24/github3.py.git

--- a/test/fabric/elasticsearch.py
+++ b/test/fabric/elasticsearch.py
@@ -1,9 +1,14 @@
 import json
+import os
+import re
+import yaml
 
 from fabric.api import env, task, run
 from envassert import detect, file, group, package, port, process, service, \
     user
 from hot.utils.test import get_artifacts
+from github3 import GitHub
+from pkg_resources import parse_version
 
 
 def es_cluster_green():
@@ -18,6 +23,40 @@ def es_cluster_green():
         return True
     else:
         return False
+
+
+def latest_template_es_version():
+    template = yaml.load(open('elasticsearch.yaml'))
+    straints = template.get('parameters').get('es_version').get('constraints')
+    versions = []
+    for constraint in straints:
+        allowed_values = constraint.get('allowed_values')
+        if allowed_values:
+            versions.extend(allowed_values)
+    highest_supported_version = '0.0.0'
+    for version in versions:
+        if parse_version(version) > parse_version(highest_supported_version):
+            highest_supported_version = version
+    print "The latest version the template supports is {}.".format(
+        highest_supported_version)
+    return "v" + highest_supported_version
+
+
+def check_for_newer_es_release():
+    most_recent_version_supported = latest_template_es_version()
+    g = GitHub(token=os.environ.get('GITHUB_TOKEN'))
+    repo = g.repository('elasticsearch', 'elasticsearch')
+    tags = [t.name for t in repo.tags()]
+    version = parse_version(most_recent_version_supported)
+    for tag in tags:
+        if tag.startswith('v') and not re.search('[Bb]eta', tag):
+            assert version >= parse_version(tag), \
+                ('It would seem there is a newer version of '
+                 'elasticsearch available: {}-- update the template '
+                 'to support it!').format(tag)
+
+    print "Looks like {} is the most".format(most_recent_version_supported), \
+          "recent version of es. The template supports that, so we're good!"
 
 
 @task
@@ -38,6 +77,7 @@ def check():
     assert service.is_enabled("nginx")
     assert service.is_enabled("elasticsearch")
     assert es_cluster_green(), "Cluster status did not return 'green'"
+    check_for_newer_es_release()
 
 
 @task


### PR DESCRIPTION
This new test determines the most recent release of Elasticsearch from the es github repo.

If the template doesn't support that version, the test fails.

This is to make us aware that there's a new release so we can update the template to support it, if possible.

Ideally, we should always support the latest.